### PR TITLE
Fix grammar in .env.example comment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@
 # should be updated accordingly.
 
 # Database URL
-# The database URL is used to connect to your database. It's used for commenting, and authentication.
+# The database URL is used to connect to your database. It’s used for commenting and authentication.
 DATABASE_URL="postgresql://postgres:<YOUR_PASSWORD>@localhost:5432/blog"
 
 # Resend


### PR DESCRIPTION
## Summary
- fix grammar for database URL description in `.env.example`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_683fd68076e483288a372ec171647958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the description of the `DATABASE_URL` environment variable for improved clarity and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->