### PR TITLE
docs: fix Podman Desktop typo

### DIFF
--- a/start-database.sh
+++ b/start-database.sh
@@ -3,7 +3,7 @@
 
 # TO RUN ON WINDOWS:
 # 1. Install WSL (Windows Subsystem for Linux) - https://learn.microsoft.com/en-us/windows/wsl/install
-# 2. Install Docker Desktop or Podman Deskop
+# 2. Install Docker Desktop or Podman Desktop
 # - Docker Desktop for Windows - https://docs.docker.com/docker-for-windows/install/
 # - Podman Desktop - https://podman.io/getting-started/installation
 # 3. Open WSL - `wsl`


### PR DESCRIPTION
## Summary
- fix Podman Desktop typo in start-database.sh

## Testing
- `pnpm lint`
- `pnpm check`


------
https://chatgpt.com/codex/tasks/task_e_683fd68a2d5083288c72ebeb854bf054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected a typographical error in the script's header instructions, updating "Deskop" to "Desktop".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->